### PR TITLE
Disable validation for contract wallets

### DIFF
--- a/src/components/Synthetics/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
+++ b/src/components/Synthetics/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -14,6 +14,7 @@ import { approveTokens } from "domain/tokens";
 import { useHasOutdatedUi } from "lib/useHasOutdatedUi";
 import { userAnalytics } from "lib/userAnalytics";
 import { TokenApproveClickEvent, TokenApproveResultEvent } from "lib/userAnalytics/types";
+import useAccountType, { AccountType } from "lib/wallets/useAccountType";
 import useWallet from "lib/wallets/useWallet";
 
 import { useDepositWithdrawalAmounts } from "./useDepositWithdrawalAmounts";
@@ -85,6 +86,8 @@ export const useGmSwapSubmitState = ({
   const hasOutdatedUi = useHasOutdatedUi();
   const { openConnectModal } = useConnectModal();
   const { account, signer } = useWallet();
+  const accountType = useAccountType();
+  const disableValidation = shouldDisableValidation || accountType === AccountType.CONTRACT;
 
   const {
     glvTokenAmount = 0n,
@@ -110,7 +113,7 @@ export const useGmSwapSubmitState = ({
     marketTokenAmount,
     glvTokenAmount,
     glvTokenUsd,
-    shouldDisableValidation,
+    shouldDisableValidation: disableValidation,
     tokensData,
     executionFee,
     selectedMarketForGlv,
@@ -198,7 +201,7 @@ export const useGmSwapSubmitState = ({
     if (error) {
       return {
         text: error,
-        disabled: !shouldDisableValidation,
+        disabled: !disableValidation,
         onClick: onSubmit,
         errorDescription: swapErrorDescription,
       };
@@ -285,7 +288,7 @@ export const useGmSwapSubmitState = ({
     isDeposit,
     onSubmit,
     onConnectAccount,
-    shouldDisableValidation,
+    disableValidation,
     swapErrorDescription,
     chainId,
     tokensData,

--- a/src/domain/synthetics/orders/simulation.ts
+++ b/src/domain/synthetics/orders/simulation.ts
@@ -8,6 +8,7 @@ import {
   getMulticallContract,
   getZeroAddressContract,
 } from "config/contracts";
+import { isDevelopment } from "config/env";
 import { isGlvEnabled } from "domain/synthetics/markets/glv";
 import { SwapPricingType } from "domain/synthetics/orders";
 import { TokenPrices, TokensData, convertToContractPrice, getTokenData } from "domain/synthetics/tokens";
@@ -19,7 +20,6 @@ import { abis } from "sdk/abis";
 import { convertTokenAddress } from "sdk/configs/tokens";
 import { CustomErrorName, ErrorData, TxErrorType, extendError, isContractError, parseError } from "sdk/utils/errors";
 import { CreateOrderTxnParams, ExternalCallsPayload } from "sdk/utils/orderTransactions";
-import { isDevelopment } from "config/env";
 
 export type SimulateExecuteParams = {
   account: string;


### PR DESCRIPTION
## Summary
- automatically skip GM swap simulation when connected wallet is a contract account
- restore express order gas balance validation
- fix import order warning

## Testing
- `yarn lint`
- `yarn test:ci`


------
https://chatgpt.com/codex/tasks/task_e_688c6ffe876883269561d1fe87cd0b9f